### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#RX Heroes
-##The Angular 2 Tour of Heroes Tutorial app rewritten with @ngrx/store
+# RX Heroes
+## The Angular 2 Tour of Heroes Tutorial app rewritten with @ngrx/store
 
 See my [post about this](https://bodiddlie.github.io/ng-2-toh-with-ngrx-suite/) for the full
 story.
 
-##Update - 09/25/2016
+## Update - 09/25/2016
 This repo has been updated to work with the final release of Angular 2 final. It's not perfect, and I would suggest that you NOT consider this
 as an example of best practices, but it will give you an idea of how these pieces fit together. Here's a quick rundown of what changed:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
